### PR TITLE
ensure arm build jobs are on the same machine

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -65,7 +65,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     steps {
                         sh "docker pull vaporio/buildpack-deps:bionic"
@@ -91,7 +93,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     environment {
                         buildArch = "arm64"
@@ -121,7 +125,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     environment {
                         buildArch = "arm64"
@@ -151,7 +157,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     environment {
                         buildArch = "arm64"
@@ -181,7 +189,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     environment {
                         buildArch = "arm64"
@@ -212,7 +222,9 @@ pipeline {
 
                 stage('arm64') {
                     agent {
-                        label 'arm64'
+                        node {
+                            label 'arm0'
+                        }
                     }
                     environment {
                         buildArch = "arm64"


### PR DESCRIPTION
We currently have two build machines defined for arm -- picklerick and arm0

Since we were previously just targeting a node with an arm64 label, we ran into the possibility that the image builds could happen on one machine and the push on another (where those images do not exist). This PR updates the agent config for arm64 build to ensure they all occur on the same machine.

It doesn't feel pretty and will need to change if we ever get rid of the 'arm0' machine, but we kinda need it right now to ensure builds work consistently.