### PR TITLE
Update CI config for py3.10

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,4 +1,4 @@
-def versions = ["3.10", "3.9", "3.8", "3.7", "3.6"]
+def versions = ["3.10-rc", "3.9", "3.8", "3.7", "3.6"]
 
 def generatePublishStage(job) {
     return {


### PR DESCRIPTION
I'm  not 100% on this, but I think  this  is the reason the publish stage is failing (https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fpython/detail/master/1535/pipeline/273) --  I believe  its looking for a `3.10` tagged image, when  it should be a `3.10-rc` tagged image.